### PR TITLE
Move sudo roles to their own table in SQL, fix some bugs elsewhere

### DIFF
--- a/tg_bot/__init__.py
+++ b/tg_bot/__init__.py
@@ -13,12 +13,13 @@ from configparser import ConfigParser
 from rich.logging import RichHandler
 from ptbcontrib.postgres_persistence import PostgresPersistence
 
-
 StartTime = time.time()
 
-def get_user_list(__init__, key):
-    with open("{}/tg_bot/{}".format(os.getcwd(), __init__), "r") as json_file:
-        return json.load(json_file)[key]
+def get_user_list(key):
+    # Import here to evade a circular import
+    from tg_bot.modules.sql import nation_sql
+    royals = nation_sql.get_royals(key)
+    return [a.user_id for a in royals]
 
 # enable logging
 FORMAT = "[Enterprise] %(message)s"
@@ -65,12 +66,12 @@ MESSAGE_DUMP = kigconfig.getfloat("MESSAGE_DUMP")
 GBAN_LOGS = kigconfig.getfloat("GBAN_LOGS")
 NO_LOAD = kigconfig.get("NO_LOAD").split()
 NO_LOAD = list(map(str, NO_LOAD))
-SUDO_USERS = get_user_list("elevated_users.json", "sudos")
-DEV_USERS = get_user_list("elevated_users.json", "devs")
-SUPPORT_USERS = get_user_list("elevated_users.json", "supports")
-SARDEGNA_USERS = get_user_list("elevated_users.json", "sardegnas")
-WHITELIST_USERS = get_user_list("elevated_users.json", "whitelists")
-SPAMMERS = get_user_list("elevated_users.json", "spammers")
+SUDO_USERS = [OWNER_ID] + get_user_list("sudos")
+DEV_USERS = [OWNER_ID] + get_user_list("devs")
+SUPPORT_USERS = get_user_list("supports")
+SARDEGNA_USERS = get_user_list("sardegnas")
+WHITELIST_USERS = get_user_list("whitelists")
+SPAMMERS = get_user_list("spammers")
 spamwatch_api = kigconfig.get("spamwatch_api")
 CASH_API_KEY = kigconfig.get("CASH_API_KEY")
 TIME_API_KEY = kigconfig.get("TIME_API_KEY")
@@ -82,10 +83,6 @@ try:
 except:
     log.info("[NLP] No Coffeehouse API key provided.")
     CF_API_KEY = None
-
-
-SUDO_USERS.append(OWNER_ID)
-DEV_USERS.append(OWNER_ID)
 
 # SpamWatch
 if spamwatch_api is None:
@@ -100,7 +97,6 @@ else:
 
 
 from tg_bot.modules.sql import SESSION
-
 
 updater = tg.Updater(TOKEN, workers=min(32, os.cpu_count() + 4), request_kwargs={"read_timeout": 10, "connect_timeout": 10}, persistence=PostgresPersistence(SESSION))
 telethn = TelegramClient(MemorySession(), APP_ID, API_HASH)
@@ -136,14 +132,6 @@ async def get_entity(client, entity):
                 entity = await kp.get_chat(entity)
                 entity_client = kp
     return entity, entity_client
-
-
-SUDO_USERS = list(SUDO_USERS) + list(DEV_USERS)
-DEV_USERS = list(DEV_USERS)
-WHITELIST_USERS = list(WHITELIST_USERS)
-SUPPORT_USERS = list(SUPPORT_USERS)
-SARDEGNA_USERS = list(SARDEGNA_USERS)
-SPAMMERS = list(SPAMMERS)
 
 # Load at end to ensure all prev variables have been set
 from tg_bot.modules.helper_funcs.handlers import CustomCommandHandler

--- a/tg_bot/elevated_users.json
+++ b/tg_bot/elevated_users.json
@@ -1,8 +1,0 @@
-{
-    "devs": [],
-    "supports": [],
-    "whitelists": [],
-    "sudos": [],
-    "sardegnas": [],
-    "spammers": []
-}

--- a/tg_bot/modules/misc.py
+++ b/tg_bot/modules/misc.py
@@ -7,7 +7,7 @@ import requests
 from telegram import Update, MessageEntity, ParseMode
 from telegram.error import BadRequest
 from telegram.ext import CommandHandler, Filters, CallbackContext
-from telegram.utils.helpers import mention_html
+from telegram.utils.helpers import mention_html, escape_markdown
 from subprocess import Popen, PIPE
 
 from tg_bot import (
@@ -23,6 +23,7 @@ from tg_bot import (
     StartTime
 )
 from tg_bot.__main__ import STATS, USER_INFO, TOKEN
+from tg_bot.modules.sql import SESSION
 from tg_bot.modules.disable import DisableAbleCommandHandler
 from tg_bot.modules.helper_funcs.chat_status import user_admin, sudo_plus
 from tg_bot.modules.helper_funcs.extraction import extract_user
@@ -364,15 +365,16 @@ def get_readable_time(seconds: int) -> str:
 
 @sudo_plus
 def stats(update, context):
+    db_size = SESSION.execute("SELECT pg_size_pretty(pg_database_size(current_database()))").scalar_one_or_none()
     uptime = datetime.datetime.fromtimestamp(boot_time()).strftime("%Y-%m-%d %H:%M:%S")
     botuptime = get_readable_time((time.time() - StartTime))
     status = "*System statistics*\n"
     status += "*• System uptime:* " + str(uptime) + "\n"
     uname = platform.uname()
     status += "*• System:* " + str(uname.system) + "\n"
-    status += "*• Node name:* " + str(uname.node) + "\n"
-    status += "*• Release:* " + str(uname.release) + "\n"
-    status += "*• Machine:* " + str(uname.machine) + "\n"
+    status += "*• Node name:* " + escape_markdown(str(uname.node)) + "\n"
+    status += "*• Release:* " + escape_markdown(str(uname.release)) + "\n"
+    status += "*• Machine:* " + escape_markdown(str(uname.machine)) + "\n"
 
     mem = virtual_memory()
     cpu = cpu_percent()
@@ -383,6 +385,7 @@ def stats(update, context):
     status += "*• Python version:* " + python_version() + "\n"
     status += "*• Library version:* " + str(__version__) + "\n"
     status += "*• Bot uptime:* " + str(botuptime) + "\n"
+    status += "*• Database size:* " + str(db_size) + "\n"
 
     repo = git.Repo(search_parent_directories=True)
     sha = repo.head.object.hexsha

--- a/tg_bot/modules/sql/__init__.py
+++ b/tg_bot/modules/sql/__init__.py
@@ -4,14 +4,12 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 
 from tg_bot import DB_URI, log
 
-
 def start() -> scoped_session:
     engine = create_engine(DB_URI, client_encoding="utf8")
     log.info("[PostgreSQL] Connecting to database......")
     BASE.metadata.bind = engine
     BASE.metadata.create_all(engine)
     return scoped_session(sessionmaker(bind=engine, autoflush=False))
-
 
 BASE = declarative_base()
 SESSION = start()

--- a/tg_bot/modules/sql/nation_sql.py
+++ b/tg_bot/modules/sql/nation_sql.py
@@ -1,0 +1,68 @@
+import threading
+import traceback
+from tg_bot.modules.sql import BASE, SESSION
+from sqlalchemy import Boolean, Column, Integer, String, UnicodeText, distinct, func
+from sqlalchemy.dialects import postgresql
+
+class Royals(BASE):
+	__tablename__ = "royals"
+
+	user_id = Column(Integer, primary_key=True)
+	role_name = Column(String(255))
+	
+	def __init__(self, user_id, role):
+		self.user_id = user_id
+		self.role_name = role
+
+	def __repr__(self):
+		return f"<royal {self.user_id} with role {self.role_name}>"
+
+Royals.__table__.create(checkfirst=True)
+
+def is_royal(user_id: int, role: str = None):
+	with SESSION() as local_session:
+		if role:
+			return bool(local_session.query(Royals).get((user_id, role)))
+		else:
+			return bool(local_session.query(Royals).get(user_id))
+
+def get_royal_role(user_id: int):
+	with SESSION() as local_session:
+		ret = local_session.query(Royals).get({"user_id": user_id})
+		if ret:
+			return ret.role_name
+	return None
+
+def get_royals(role: str = None):
+	with SESSION() as local_session:
+		if not role:
+			return local_session.query(Royals).all()
+		else:
+			return local_session.query(Royals).filter(Royals.role_name == role).all()
+
+def set_royal_role(user_id: int, role: str):
+	with SESSION() as local_session:
+		try:
+			# Check if the user exists first and create them if they don't.
+			ret = local_session.query(Royals).get({"user_id": user_id})
+			if not ret:
+				ret = Royals(user_id, role)
+				local_session.add(ret)
+			else:
+				ret.role_name = role
+			local_session.commit()
+			local_session.flush()
+		except Exception:
+			traceback.print_exc()
+			local_session.rollback()
+
+def remove_royal(user_id: int):
+	with SESSION() as local_session:
+		try:
+			ret = local_session.query(Royals).get({"user_id": user_id})
+			if ret:
+				local_session.delete(ret)
+			local_session.commit()
+		except Exception:
+			traceback.print_exc()
+			local_session.rollback()

--- a/tg_bot/modules/term_and_eval.py
+++ b/tg_bot/modules/term_and_eval.py
@@ -2,6 +2,7 @@ import traceback
 import sys
 import os
 import re
+import html
 import subprocess
 from io import StringIO, BytesIO
 from tg_bot import kp, OWNER_ID
@@ -42,18 +43,17 @@ async def evaluate(client, message):
     sys.stderr = old_stderr
     evaluation = ""
     if exc:
-        evaluation = exc
-    elif stderr:
-        evaluation = stderr
-    elif stdout:
-        evaluation = stdout
-    else:
-        evaluation = "Success"
-    final_output = f"<b>OUTPUT</b>:\n<code>{evaluation.strip()}</code>"
-    if len(final_output) > 4096:
+        evaluation = f"<b>Exception:</b>\n<code>{html.escape(exc)}</code>\n"
+    if stderr:
+        evaluation += f"<b>STDERR:</b>\n<code>{html.escape(stderr)}</code>\n"
+    if stdout:
+        evaluation += f"<b>STDOUT:</b>\n<code>{html.escape(stdout)}</code>\n"
+    if not evaluation:
+        evaluation = "Success but no output!"
+    if len(evaluation) > 4096:
         filename = 'output.txt'
         with open(filename, "w+", encoding="utf8") as out_file:
-            out_file.write(str(final_output))
+            out_file.write(str(evaluation))
         await message.reply_document(
             document=filename,
             caption=cmd,
@@ -63,7 +63,7 @@ async def evaluate(client, message):
         os.remove(filename)
         await status_message.delete()
     else:
-        await status_message.edit(final_output)
+        await status_message.edit(evaluation)
 
 
 


### PR DESCRIPTION
Moved sudo roles to their own SQL table which allows them to persist and not use the old json format like before. This should be thread-safe so hopefully it will also be somewhat fast. I also added the database size to the /stats command and fixed a bug where stuff wasn't escaped and would cause the command to fail and use the minimal stats format instead of the proper one. Also fixed a bug in /eval where stuff also wasn't escaped and would cause stuff to not show up in the output, I also differentiated exceptions, stdout, and stderr from each other so it's clearer what's happening.